### PR TITLE
Support for class declarations

### DIFF
--- a/src/com/yalija/main/Interpreter.java
+++ b/src/com/yalija/main/Interpreter.java
@@ -139,6 +139,13 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
     return null;
   }
 
+  @Override
+  public Void visitClassStmt(Stmt.Class stmt) {
+    environment.define(stmt.name.lexeme, null);
+    LoxClass klass = new LoxClass(stmt.name.lexeme);
+    environment.assign(stmt.name, klass);
+    return null;
+  }
 
   @Override
   public Void visitExpressionStmt(Stmt.Expression stmt) {

--- a/src/com/yalija/main/LoxClass.java
+++ b/src/com/yalija/main/LoxClass.java
@@ -1,0 +1,14 @@
+package com.yalija.main;
+
+public class LoxClass {
+  final String name;
+
+  LoxClass(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return name;
+  }
+}

--- a/src/com/yalija/main/Parser.java
+++ b/src/com/yalija/main/Parser.java
@@ -204,6 +204,7 @@ public class Parser {
 
   private Stmt declaration() {
     try {
+      if (match(TokenType.CLASS)) return classDeclaration();
       if (match(TokenType.FUNCTION)) return function("function");
       if (match(TokenType.VAR)) return varDeclaration();
       return statement();
@@ -211,6 +212,19 @@ public class Parser {
       synchronize();
       return null;
     }
+  }
+
+  private Stmt classDeclaration() {
+    Token name = consume(TokenType.IDENTIFIER, "Expect class name.");
+    consume(TokenType.OPENING_BRACE, "Expect '{' before class body");
+
+    List<Stmt.Function> methods = new ArrayList<>();
+    while (!check(TokenType.CLOSING_BRACE) && !isAtEnd()) {
+      methods.add(function("method"));
+    }
+
+    consume(TokenType.CLOSING_BRACE, "Expect '}' after class body.");
+    return new Stmt.Class(name, methods);
   }
 
   private Stmt varDeclaration() {

--- a/src/com/yalija/main/Resolver.java
+++ b/src/com/yalija/main/Resolver.java
@@ -83,6 +83,13 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
   }
 
   @Override
+  public Void visitClassStmt(Stmt.Class stmt) {
+    declare(stmt.name);
+    define(stmt.name);
+    return null;
+  }
+
+  @Override
   public Void visitExpressionStmt(Stmt.Expression stmt) {
     resolve(stmt.expression);
     return null;

--- a/src/com/yalija/main/Stmt.java
+++ b/src/com/yalija/main/Stmt.java
@@ -5,6 +5,7 @@ import java.util.List;
 abstract class Stmt {
   interface Visitor<R> {
     R visitBlockStmt(Block stmt);
+    R visitClassStmt(Class stmt);
     R visitExpressionStmt(Expression stmt);
     R visitFunctionStmt(Function stmt);
     R visitIfStmt(If stmt);
@@ -25,6 +26,21 @@ abstract class Stmt {
     }
 
     final List<Stmt> statements;
+  }
+
+  static class Class extends Stmt {
+    Class (Token name, List<Stmt.Function> methods) {
+      this.name = name;
+      this.methods = methods;
+    }
+
+    @Override
+    <R> R accept(Visitor<R> visitor) {
+      return visitor.visitClassStmt(this);
+    }
+
+    final Token name;
+    final List<Stmt.Function> methods;
   }
 
   static class Expression extends Stmt {

--- a/src/com/yalija/tool/ASTGenerator.java
+++ b/src/com/yalija/tool/ASTGenerator.java
@@ -29,6 +29,7 @@ public class ASTGenerator {
 
     defineAST(outputDir, "Stmt", Arrays.asList(
             "Block      : List<Stmt> statements",
+            "Class      : Token name, List<Stmt.Function> methods",
             "Expression : Expr expression",
             "Function   : Token name, List<Token> params, List<Stmt> body",
             "If         : Expr condition, Stmt thenBranch, Stmt elseBranch",


### PR DESCRIPTION
This PR contains only minimal support for class declarations. The most it can do is print the class name. For example, this code,
```
class DevonshireCream {
  serveOn() {
    return "Scones";
  }
}

print DevonshireCream;
```
will print `DevonshireCream` to the console.