### PR TITLE
Add support for "this" keyword

### DIFF
--- a/src/com/yalija/main/Expr.java
+++ b/src/com/yalija/main/Expr.java
@@ -12,6 +12,7 @@ abstract class Expr {
     R visitLiteralExpr(Literal expr);
     R visitLogicalExpr(Logical expr);
     R visitSetExpr(Set expr);
+    R visitThisExpr(This expr);
     R visitUnaryExpr(Unary expr);
     R visitVariableExpr(Variable expr);
   }
@@ -138,6 +139,19 @@ abstract class Expr {
     final Expr object;
     final Token name;
     final Expr value;
+  }
+
+  static class This extends Expr {
+    This (Token keyword) {
+      this.keyword = keyword;
+    }
+
+    @Override
+    <R> R accept(Visitor<R> visitor) {
+      return visitor.visitThisExpr(this);
+    }
+
+    final Token keyword;
   }
 
   static class Unary extends Expr {

--- a/src/com/yalija/main/Interpreter.java
+++ b/src/com/yalija/main/Interpreter.java
@@ -296,6 +296,11 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
   }
 
   @Override
+  public Object visitThisExpr(Expr.This expr) {
+    return lookUpVariable(expr.keyword, expr);
+  }
+
+  @Override
   public Object visitCallExpr(Expr.Call expr) {
     Object callee = evaluate(expr.callee);
 

--- a/src/com/yalija/main/LoxFunction.java
+++ b/src/com/yalija/main/LoxFunction.java
@@ -11,6 +11,12 @@ public class LoxFunction implements LoxCallable {
     this.declaration = declaration;
   }
 
+  LoxFunction bind(LoxInstance instance) {
+    Environment environment = new Environment(closure);
+    environment.define("this", instance);
+    return new LoxFunction(declaration, environment);
+  }
+
   @Override
   public String toString() {
     return "<fn " + declaration.name.lexeme + ">";

--- a/src/com/yalija/main/LoxInstance.java
+++ b/src/com/yalija/main/LoxInstance.java
@@ -17,7 +17,7 @@ public class LoxInstance {
     }
 
     LoxFunction method = klass.findMethod(name.lexeme);
-    if (method != null) return method;
+    if (method != null) return method.bind(this);
 
     throw new RuntimeError(name, "Undefined property '" + name.lexeme + "'.");
   }

--- a/src/com/yalija/main/Parser.java
+++ b/src/com/yalija/main/Parser.java
@@ -348,6 +348,8 @@ public class Parser {
       return new Expr.Literal(previous().literal);
     }
 
+    if (match(TokenType.THIS)) return new Expr.This(previous());
+
     if (match(TokenType.IDENTIFIER)) {
       return new Expr.Variable(previous());
     }

--- a/src/com/yalija/main/Resolver.java
+++ b/src/com/yalija/main/Resolver.java
@@ -20,6 +20,13 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
     METHOD
   }
 
+  private enum ClassType {
+    NONE,
+    CLASS
+  }
+
+  private ClassType currentClass = ClassType.NONE;
+
   public void resolve(List<Stmt> statements) {
     for (Stmt statement : statements) {
       resolve(statement);
@@ -85,14 +92,23 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
 
   @Override
   public Void visitClassStmt(Stmt.Class stmt) {
+    ClassType enclosingClass = currentClass;
+    currentClass = ClassType.CLASS;
+
     declare(stmt.name);
     define(stmt.name);
+
+    beginScope();
+    scopes.peek().put("this", true);
 
     for (Stmt.Function method : stmt.methods) {
       FunctionType declaration = FunctionType.METHOD;
       resolveFunction(method, declaration);
     }
 
+    endScope();
+
+    currentClass = enclosingClass;
     return null;
   }
 
@@ -209,6 +225,17 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
   public Void visitSetExpr(Expr.Set expr) {
     resolve(expr.value);
     resolve(expr.object);
+    return null;
+  }
+
+  @Override
+  public Void visitThisExpr(Expr.This expr) {
+    if (currentClass == ClassType.NONE) {
+      Lox.error(expr.keyword, "Can't use 'this' outside of a class.");
+      return null;
+    }
+
+    resolveLocal(expr, expr.keyword);
     return null;
   }
 

--- a/src/com/yalija/tool/ASTGenerator.java
+++ b/src/com/yalija/tool/ASTGenerator.java
@@ -25,6 +25,7 @@ public class ASTGenerator {
             "Literal    : Object value",
             "Logical    : Expr left, Token operator, Expr right",
             "Set        : Expr object, Token name, Expr value",
+            "This       : Token keyword",
             "Unary      : Token operator, Expr right",
             "Variable   : Token name"
     ));


### PR DESCRIPTION
This PR adds support for the "this" keyword that we usually find in languages like Java and C++,
for example, this code,
```
class Thing {
   getCallback() {
     fun localFunction() {
       print "Hi! I'm a local function";
     }

     return localFunction;
   }
 }

 var callback = Thing().getCallback();
 callback();
```

will print, 
```
Hi! I'm a local function
```

## Prevent inappropriate usage of "this"

This PR also includes the necessary machinery to prevent users from using the "this" keyword outside of classes.
For example, this code,
```
print this;
```

will print,
```
[line 1] Error at 'this': Can't use 'this' outside of a class.
```