### PR TITLE
Add support for class initializer

### DIFF
--- a/src/com/yalija/main/Interpreter.java
+++ b/src/com/yalija/main/Interpreter.java
@@ -158,7 +158,8 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
 
     Map<String, LoxFunction> methods = new HashMap<>();
     for (Stmt.Function method : stmt.methods) {
-      LoxFunction function = new LoxFunction(method, environment);
+      LoxFunction function = new LoxFunction(method, environment,
+              method.name.lexeme.equals("init"));
       methods.put(method.name.lexeme, function);
     }
 
@@ -175,7 +176,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
 
   @Override
   public Void visitFunctionStmt(Stmt.Function stmt) {
-    LoxFunction function = new LoxFunction(stmt, environment);
+    LoxFunction function = new LoxFunction(stmt, environment, false);
     environment.define(stmt.name.lexeme, function);
     return null;
   }

--- a/src/com/yalija/main/LoxClass.java
+++ b/src/com/yalija/main/LoxClass.java
@@ -28,11 +28,18 @@ public class LoxClass implements LoxCallable {
   @Override
   public Object call(Interpreter interpreter, List<Object> arguments) {
     LoxInstance instance = new LoxInstance(this);
+    LoxFunction initializer = findMethod("init");
+    if (initializer != null) {
+      initializer.bind(instance).call(interpreter, arguments);
+    }
+
     return instance;
   }
 
   @Override
   public int arity() {
-    return 0;
+    LoxFunction initializer = findMethod("init");
+    if (initializer == null) return 0;
+    return initializer.arity();
   }
 }

--- a/src/com/yalija/main/LoxFunction.java
+++ b/src/com/yalija/main/LoxFunction.java
@@ -6,7 +6,10 @@ public class LoxFunction implements LoxCallable {
   private final Stmt.Function declaration;
   private final Environment closure;
 
-  LoxFunction(Stmt.Function declaration, Environment closure) {
+  private final boolean isInitializer;
+
+  LoxFunction(Stmt.Function declaration, Environment closure, boolean isInitializer) {
+    this.isInitializer = isInitializer;
     this.closure = closure;
     this.declaration = declaration;
   }
@@ -14,7 +17,7 @@ public class LoxFunction implements LoxCallable {
   LoxFunction bind(LoxInstance instance) {
     Environment environment = new Environment(closure);
     environment.define("this", instance);
-    return new LoxFunction(declaration, environment);
+    return new LoxFunction(declaration, environment, isInitializer);
   }
 
   @Override
@@ -37,6 +40,8 @@ public class LoxFunction implements LoxCallable {
     try {
       interpreter.executeBlock(declaration.body, environment);
     } catch (Return returnValue) {
+      if (isInitializer) return closure.getAt(0, "this");
+
       return returnValue.value;
     }
 

--- a/src/com/yalija/main/Resolver.java
+++ b/src/com/yalija/main/Resolver.java
@@ -17,6 +17,7 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
   private enum FunctionType {
     NONE,
     FUNCTION,
+    INITIALIZER,
     METHOD
   }
 
@@ -103,6 +104,10 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
 
     for (Stmt.Function method : stmt.methods) {
       FunctionType declaration = FunctionType.METHOD;
+      if (method.name.lexeme.equals("init")) {
+        declaration = FunctionType.INITIALIZER;
+      }
+
       resolveFunction(method, declaration);
     }
 
@@ -148,6 +153,10 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
     }
 
     if (stmt.value != null) {
+      if (currentFunction == FunctionType.INITIALIZER) {
+        Lox.error(stmt.keyword, "Can't return a value from an initializer.");
+      }
+     
       resolve(stmt.value);
     }
 


### PR DESCRIPTION
Class initializers are synonymous with constructors, since we support classes, we need to support constructors too.
### Code example
This code,
```
class Car {
    init() {
        print "Engine started";
    }
}

Car();
```

will print,
```
Engine started
```